### PR TITLE
CAN-FiX Plugin Additions

### DIFF
--- a/doc/appendix/netfixascii.rst
+++ b/doc/appendix/netfixascii.rst
@@ -34,7 +34,7 @@ the FIX-Gateway :doc:`database` as a common place to configure this information.
 The ``xxxx.x`` represents the value. The value can be a float, int,
 bool or string (The string cannot contain a ;).  Floats will contain the decimal
 point, integers will not. Booleans will be 'T' or 'F' and strings will begin
-with an '&'.  the 'obf' represent the quality flags.  They will be either 1 or
+with an '&'.  the 'aobfs' represent the quality flags.  They will be either 1 or
 0. a=annunciate, o=Old, b=bad, f=failed, s=secondary fail.  The old flag is set
 if the data has not been written within the configured time to live for that
 point.  The bad is set if there is reason to doubt the data but it hasn't

--- a/fixgw/config/beaglebone.yaml
+++ b/fixgw/config/beaglebone.yaml
@@ -96,7 +96,7 @@ connections:
     module: fixgw.plugins.canfix
     # See the python-can documentation for the meaning of these options
     interface: socketcan
-    channel: can0
+    channel: vcan0
     #interface: serial
     #channel: /dev/ttyUSB0
 

--- a/fixgw/plugins/canfix/mapping.py
+++ b/fixgw/plugins/canfix/mapping.py
@@ -142,9 +142,6 @@ class Mapping(object):
 
         return outputCallback
 
-    # This opens the map file and buids the input mapping lists.
-    # def initialize(self, mapfile):
-
 
     def inputMap(self, par):
         """Retrieve the function that should be called for a given parameter"""

--- a/tests/test_canfix.py
+++ b/tests/test_canfix.py
@@ -19,6 +19,7 @@ import subprocess
 import os
 import time
 import yaml
+import random
 import can
 
 import fixgw.database as database
@@ -156,6 +157,20 @@ class TestCanfix(unittest.TestCase):
         msg = self.bus.recv(1.0)
         self.assertEqual(msg.arbitration_id, self.node + 1760)
         self.assertEqual(msg.data, bytearray([12, 0x90, 0x01, 0x58, 0x75]))
+
+
+    def test_all_frame_ids(self):
+        """Loop through every CAN ID and every length of data with random data"""
+        random.seed(14)  # We want deterministic input for testing
+        for id in range(2048):
+            for dsize in range(9):
+                msg = can.Message(is_extended_id = False, arbitration_id = id)
+                for x in range(dsize):
+                    msg.data.append(random.randrange(256))
+                msg.dlc = dsize
+                self.bus.send(msg)
+
+
 
     # We don't really have any of these yet
     # def test_owned_outputs(self):


### PR DESCRIPTION
Added a filter for incoming CAN messages and a test for seeing that the CAN-FiX plugin doesn't crash when bad data is received.