### PR TITLE
Add special encoder and button functions to canfix plugin

### DIFF
--- a/fixgw/config/canfix/map.yaml
+++ b/fixgw/config/canfix/map.yaml
@@ -88,3 +88,12 @@ inputs:
 
 outputs:
   - { fixid: "BARO", canid: 0x190, index: 0, owner: False }
+
+# Special Input Functions
+encoders:
+    - { fixid: "ENC1, ENC2, BTN11", canid: 0x300, index: 0 }
+    - { fixid: "ENC3,ENC4,BTN12", canid: 0x301, index: 0 }
+
+# Generic Switch Inputs
+switches:
+    - { fixid: "BTN1,BTN2,BTN3,BTN4,BTN5,BTN6", canid: 0x308, index: 0 }

--- a/fixgw/config/database.yaml
+++ b/fixgw/config/database.yaml
@@ -3,7 +3,7 @@ variables:
   c: 6  # Cylinders
   a: 8  # Generic Analogs
   b: 16 # Generic Buttons
-  r: 1  # Encoders
+  r: 4  # Encoders
   t: 2  # Fuel Tanks
 
 entries:


### PR DESCRIPTION
Added the ability to map encoders and generic switches.  These are special cases that didn't quite fit with the 'normal' mappings.