### PR TITLE
New plugins ifly and mavlink

### DIFF
--- a/fixgw/config/database.yaml
+++ b/fixgw/config/database.yaml
@@ -692,3 +692,84 @@ entries:
   description: Aircraft Identification
   type: str
   tol: 0
+
+# Used by mavlink plugin:
+- key: TRIMP
+  description: Pitch Trim
+  type: int
+  min: -1000
+  max: 1000
+  initial: 0
+- key: TRIMR
+  description: Roll Trim
+  type: int
+  min: -1000
+  max: 1000
+  initial: 0
+- key: TRIMY
+  description: Yaw Trim
+  type: int
+  min: -1000
+  max: 1000
+  initial: 0
+- key: BTNAP
+  description: AP button state
+  type: bool
+  initial: false
+- key: BTNHH
+  description: AP heading hold button state
+  type: bool
+  initial: false
+- key: BTNFP
+  description: AP flight plan button state
+  type: bool
+  initial: false
+- key: APSTAT
+  description: Status of auto pilot, Avaliable or not
+  type: str
+  tol: 10000
+  initial: INIT
+- key: APMODE
+  description: Mode of auto pilot, Heading Hold (CRUISE), Trim (Manual), AUTO fly to waypoint
+  type: str
+  initial: TRIM
+  tol: 10000
+- key: APMSG
+  description: Auto Pilot Message for pilot
+  type: str
+  initial: ""
+- key: APWPV
+  description: Does AP have a valid waypoint to navigate to
+  type: bool
+  initial: False
+- key: APREQ
+  description: Mode of auto pilot that is requested
+  type: str
+  initial: "INIT"
+
+# Used by ifly and mavlink
+- key: WPLAT
+  description: Waypoint Latitude
+  type: float
+  initial: 0.0
+  min: -90
+  max: 90
+  tol: 50000
+- key: WPLON
+  description: Waypoint Longitude
+  type: float
+  initial: 0.0
+  min: -90
+  max: 90
+  tol: 50000
+- key: WPNAME
+  description: Waypoint Name
+  type: str
+  tol: 50000
+  initial: ""
+- key: WPHEAD
+  description: Heading to waypoint
+  type: str
+  tol: 50000
+  initial: ""
+

--- a/fixgw/config/database.yaml
+++ b/fixgw/config/database.yaml
@@ -130,6 +130,15 @@ entries:
   initial: 101325.0
   tol: 2000
 
+- key: DIFFAIRPRESS
+  description: Differential Air Pressure
+  type: float
+  min: 0.0
+  max: 200000.0
+  units: Pa
+  initial: 101325.0
+  tol: 2000
+
 - key: VS
   description: Vertical Speed
   type: float

--- a/fixgw/config/database.yaml
+++ b/fixgw/config/database.yaml
@@ -255,7 +255,7 @@ entries:
   max: 180.0
   units: deg
   initial: 0.0
-  tol: 200
+  tol: 300
 
 - key: PITCH
   description: Pitch Angle

--- a/fixgw/config/default.yaml
+++ b/fixgw/config/default.yaml
@@ -307,6 +307,14 @@ connections:
     load: yes
     module: fixgw.plugins.stratux
 
+  mavlink:
+    load: no
+    module: fixgw.plugins.mavlink
+    type: serial
+    baud: 115200
+    port: /dev/ttyACM0
+
+
 # Logging configuration - See Python logging.config module documenation
 logging:
   version: 1

--- a/fixgw/config/default.yaml
+++ b/fixgw/config/default.yaml
@@ -315,6 +315,7 @@ connections:
     port: /dev/ttyACM0
     options:
       airspeed: true
+      groundspeed: true
       gps: true
       ahrs: true
       accel: true

--- a/fixgw/config/default.yaml
+++ b/fixgw/config/default.yaml
@@ -314,6 +314,9 @@ connections:
     baud: 115200
     port: /dev/ttyACM0
 
+  ifly:
+    load: no
+    module: fixgw.plugins.ifly
 
 # Logging configuration - See Python logging.config module documenation
 logging:

--- a/fixgw/config/default.yaml
+++ b/fixgw/config/default.yaml
@@ -313,6 +313,12 @@ connections:
     type: serial
     baud: 115200
     port: /dev/ttyACM0
+    options:
+      airspeed: true
+      gps: true
+      ahrs: true
+      accel: true
+      pressure: true
 
   ifly:
     load: no

--- a/fixgw/plugins/ifly/__init__.py
+++ b/fixgw/plugins/ifly/__init__.py
@@ -1,0 +1,129 @@
+#  Copyright (c) 2023 Eric Blevins
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+#  USA.import plugin
+
+import threading
+import time
+from collections import OrderedDict
+import fixgw.plugin as plugin
+import socket
+import struct
+import math
+import pynmea2
+import re
+
+
+# This plugin should be considered experimental
+# Use at your own risk
+# At this time it has seen no real-world use and testing
+#
+#
+# This plugin listens for NMEA data sent to port 2000 from the iFly EFB app.
+# When configuring ifly, the only NMEA data we need is RMB and APB
+# At this time it does not seem possible to capture altitude data for waypoints
+# This plugin only captures the next destination not the entire flight plan
+# It is possible to get the data about the entire plan so this could be
+# a future enhancement.
+#
+# The data is stored into three FIX database keys:
+# WPNAME = the name of the waypoint
+# WPLON = longitude of the waypoint
+# WPLAT = latitude of the waypoint
+
+
+# Potential issues:
+#  Getting iFly to send to the FIX gateway might be a problem, it only seems to send to
+#  the address 192.168.1.1
+#  If you run iFly on waydroid and have waydroid running on the same computer
+#  as the Fix gateway you can add that IP address to the waydroid0 interface
+#  and this plugin will pickup the data from iFly
+#
+#  sudo ip addr add 192.168.1.1/24 dev waydroid0
+#
+#  Once when I inserted a new stop into the flight plan I observed the destination programmed into
+#  the flight controller flipping back and forth between the old and new destination
+#  I have since been unable to reproduce this error
+
+from pynmea2 import nmea_utils
+class MainThread(threading.Thread):
+    def __init__(self, parent):
+        super(MainThread, self).__init__()
+        print("running ifly plugin")
+        self.getout = False   # indicator for when to stop
+        self.parent = parent  # parent plugin object
+        self.log = parent.log  # simplifies logging
+
+        self.s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.s.bind(('', 2000))
+
+    def run(self):
+
+        while not self.getout:
+            msg, (adr, port) = self.s.recvfrom(8192)
+
+            if len(msg) < 1:
+                continue
+            nmea_msg = re.findall(r"\$.*$", msg.decode(errors='ignore'),re.M)
+            if len(nmea_msg) > 0:
+                data = pynmea2.parse(nmea_msg[0])
+                if data.sentence_type == 'RMB':
+                    # Info about destination, only sent when waypoint is active
+                    lat = -1
+                    lon = -1
+                    if data.dest_lat_dir == 'N':
+                        lat = 1
+                    if data.dest_lon_dir == 'E':
+                        long = 1  
+                    self.parent.db_write("WPLAT", lat * nmea_utils.dm_to_sd(data.dest_lat))
+                    self.parent.db_write("WPLON", lon * nmea_utils.dm_to_sd(data.dest_lon))
+
+                    self.parent.db_write("WPNAME", data.dest_waypoint_id)
+
+                elif data.sentence_type == "APB":
+                    head_type = ""
+                    if data.heading_to_dest_type == "T":
+                        head_type = " True"
+                    elif data.heading_to_dest_type == "M":
+                        head_type = " Mag"
+                    self.parent.db_write("WPHEAD",f"{data.heading_to_dest}{head_type}")
+ 
+        self.running = False
+
+
+    def stop(self):
+        self.getout = True
+
+
+class Plugin(plugin.PluginBase):
+    def __init__(self, name, config):
+        super(Plugin, self).__init__(name, config)
+        self.thread = MainThread(self)
+        self.status = OrderedDict()
+
+    def run(self):
+
+        self.thread.start()
+
+    def stop(self):
+        self.thread.stop()
+        if self.thread.is_alive():
+            self.thread.join(1.0)
+        if self.thread.is_alive():
+            raise plugin.PluginFail
+
+    def get_status(self):
+        return self.status
+

--- a/fixgw/plugins/mavlink/Mav.py
+++ b/fixgw/plugins/mavlink/Mav.py
@@ -47,6 +47,10 @@ class Mav:
         self._ahrs = options.get('ahrs', False)
         self._accel = options.get('accel', False)
         self._pressure = options.get('pressure', False)
+        # Pressure sensors are typically quite accurate at detecting pressure change with altitude
+        # but they are often quite inaccurate on the exact pressure
+        # This option allows adding/subtracting from the reading to make it more accurate
+        self._pascal_offset = options.get('pascal_offset', 0)
 
         self._waypoint = str           # The current known waypoint 
         self.setStat('ERROR', 'No Communication')
@@ -150,7 +154,7 @@ class Mav:
                 self.parent.db_write("LONG",msg.lon/10000000.0)       # int32_t degE7 10**7
         elif msg_type == "SCALED_PRESSURE":
             if self._pressure:
-                self.parent.db_write("AIRPRESS", round(msg.press_abs * 100,4))       # float hPa to Pa 
+                self.parent.db_write("AIRPRESS", round((msg.press_abs * 100) + self._pascal_offset,4))       # float hPa to Pa 
                 self.parent.db_write("DIFFAIRPRESS", round(msg.press_diff * 100,4))  # float hPa to Pa
                 # We can also get temperature and temperature_press_diff i cDegC
                 # HIGHRES_IMU might also be useful

--- a/fixgw/plugins/mavlink/Mav.py
+++ b/fixgw/plugins/mavlink/Mav.py
@@ -1,0 +1,351 @@
+#  Copyright (c) 2023 Eric Blevins
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+#  USA.import plugin
+
+from pymavlink import mavutil, mavwp
+
+from os import stat
+import math
+import time 
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Mav:
+    def __init__(self, parent, conn_type='serial',port='/dev/ttyACM0',baud=57600):
+        # Currently all that is supported is serial so conn_type is not yet used
+        self.parent = parent
+
+        self._apreq = 'INIT'           # Requested mode
+        self._apstat = 'INIT'          # Current status
+        self._apmode = 'INIT'
+        self._apwpv = False            # valid waypoint or not
+
+        self._apmodes = dict() # List of customs modes we use with TRIM being default
+        self._apmodes['TRIM'] = 0
+        self._apmodes['CRUISE'] = 7
+        self._apmodes['AUTOTUNE'] = 8
+        self._apmodes['AUTO'] = 10
+        self._apmodes['GUIDED'] = 15
+
+        self._waypoint = str           # The current known waypoint 
+        self.setStat('ERROR', 'No Communication')
+
+        if not stat(port):
+            self.setStat('ERROR', 'No Communication')
+            raise Exception(f"serial port {port} is not found!")
+        # When using USB serial when flight computer boots it creates /dev/ttyASM0
+        # But then removes it and re-creates it again, we want to ensure we open the correct one so we wait and check again
+        time.sleep(5)
+        if not stat(port):
+            self.setStat('ERROR', 'No Communication')
+            raise Exception(f"serial port {port} is not found!")
+
+        # Connect
+        self.conn = mavutil.mavlink_connection(port, baud=baud)
+
+        for msg_id in [mavutil.mavlink.MAVLINK_MSG_ID_VFR_HUD,mavutil.mavlink.MAVLINK_MSG_ID_ATTITUDE,mavutil.mavlink.MAVLINK_MSG_ID_SCALED_IMU]:
+            # Send message requesting info every 100ms
+            message = self.conn.mav.command_long_encode(
+                self.conn.target_system,
+                self.conn.target_component,
+                mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL,
+                0,
+                msg_id,  # param1: message ID
+                100,     # param2: interval in microseconds
+                0,       # param3: not used
+                0,       # param4: not used
+                0,       # param5: not used
+                0,       # param5: not used
+                0        # param6: not used
+            )
+            # Send the command 
+            self.conn.mav.send(message)
+
+        # Init data
+        self.init()
+
+    def close(self):
+        self.conn.close()
+
+    def wait_heartbeat(self):
+        self.conn.wait_heartbeat()
+
+    def process(self):
+        # Process recenived messages
+        msg = self.conn.recv_match()
+        if not msg:
+          return
+        msg_type = msg.get_type()
+        if msg_type == 'VFR_HUD':
+            #logger.debug(msg)
+            # We can also get other info like GS, VS, MSL, HEAD from this
+            # I'm not 100% sure if this is TAS or IAS
+            self.parent.db_write("TAS", msg.airspeed * 1.9438445) #m/s to knots
+
+        elif msg_type == 'SCALED_IMU':
+            #logger.debug(msg.yacc/1000)
+            # mavlink is in mG
+            # Not exactly sure if G is what pyefis expects for ALAT
+            # We can also get other data like xacc and zacc
+            self.parent.db_write("ALAT", msg.yacc/1000)
+        elif msg_type == "ATTITUDE":
+            self.parent.db_write("ROLL", math.degrees(msg.roll))
+            self.parent.db_write("PITCH", math.degrees(msg.pitch))
+            #self.parent.db_write("YAW", math.degrees(msg.yaw))
+        elif msg_type == "GLOBAL_POSITION_INT":
+            self.parent.db_write("HEAD", msg.hdg/100)             # uint16_t cdeg 
+            self.parent.db_write("VS", msg.vz *  1.96850394)      # int16_t cm/s to ft/min
+            self.parent.db_write("AGL", msg.relative_alt / 304.8) # int32_t mm to ft
+            self.parent.db_write("ALT", msg.alt / 304.8)          # int32_t mm to ft
+            self.parent.db_write("LAT",msg.lat/10000000.0)        # int32_t degE7 10**7
+            self.parent.db_write("LONG",msg.lon/10000000.0)       # int32_t degE7 10**7
+        #if msg_type == "EKF_STATUS_REPORT":
+        # This might be useful to get some info about the state of the
+        # imus/gyros
+        #    print(msg)
+        elif msg_type == "HEARTBEAT":
+            # Heartbeat type 27 = ADSB Not sure what to do with this yet so not implemented
+            # heartbeat type 1 = fixed wing
+            if msg.type == 1:
+              # custom_mode has current flight mode
+              # 0 = manual, 8 = autotune, 10 = auto, 7 = cruise https://ardupilot.org/plane/docs/parameters.html#fltmod
+              
+              logger.debug(f"custom_mode: {msg.custom_mode}") # What mode we are in
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED !=0:
+                  logger.debug("MAV_MODE_FLAG_SAFETY_ARMED")
+                  # This status means we are ARMED and can use more than just TRIM mode
+                  self.setStat('ARMED')
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_MANUAL_INPUT_ENABLED	 !=0:
+                  logger.debug("MAV_MODE_FLAG_MANUAL_INPUT_ENABLED	")
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_HIL_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_HIL_ENABLED")
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_STABILIZE_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_STABILIZE_ENABLED")
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_GUIDED_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_GUIDED_ENABLED")
+                  #self.setStat('ARMED', 'Ready')
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_AUTO_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_AUTO_ENABLED")
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_TEST_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_TEST_ENABLED")
+              if msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED !=0:
+                  logger.debug("MAV_MODE_FLAG_CUSTOM_MODE_ENABLED")
+
+              # TODO Maybe we only want to do this if the mode in flight controller is different than what we think it is
+              # Or having this set could be useful from APMODE old           
+              if msg.custom_mode == self._apmodes['TRIM']:
+                  # TRIM mode allows manual control of servos
+                  self.sendMode("TRIM", "Trim Mode")
+                  self.checkInit('TRIM')
+
+              elif msg.custom_mode == self._apmodes['CRUISE']:
+                  # CRUISE mode is like heading hold
+                  # Using the TRIM inputs you could change
+                  # course or altitude
+                  self.sendMode("CRUISE", "Heading Hold")
+                  self.checkInit('CRUISE')
+
+              elif msg.custom_mode == self._apmodes['AUTOTUNE']:
+                  # AUTOTUNE helps to train the auto pilot
+                  # You have to make full trim deflections on all axis
+                  # numerous times for it to learn how best
+                  # to control your aircraft
+                  self.sendMode("AUTOTUNE", "Auto Tune")
+                  self.checkInit('AUTOTUNE')
+
+              elif msg.custom_mode == self._apmodes['GUIDED']:
+                  # Will navigate to a pont defined by fix keys:
+                  # WPLON, WPLAT
+                  # Also uses WPNAME for the name of the waypoint.
+                  # Altitude is set to your current altitude MSL
+                  # Trims can be used to change altitude
+                  # Maybe we can add other methods in the future.
+                  self.sendMode("GUIDED", f"Nav to: {self.parent.db_read('WPNAME')[0]}")
+                  self.checkInit('GUIDED')
+
+              else:
+                  self.parent.db_write("APMODE", "UNKNOWN")
+                  self.setStat('ERROR', 'Unknown Condition')
+                  # TODO Likely need to do more here
+                  # But we should never end up here in the first place
+
+        elif msg_type == "SYS_STATUS":
+            # Can we arm? 
+            if msg.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK !=0:
+                # Arming checks pass, we can arm now
+
+                # If not armed, arm
+                if not self._apstat == 'ARMED':
+                    message = self.conn.mav.command_long_encode(
+                        self.conn.target_system,
+                        self.conn.target_component,
+                        mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                        0,       # Confirmation
+                        1,       # param1: 1 = arm 0 = disarm
+                        100,     # param2: 
+                        0,       # param3 not used
+                        0,       # param4 not used
+                        0,       # param5 not used
+                        0,       # param5 not used
+                        0        # param6 not used
+                    )
+                    # Send the command
+                    self.conn.mav.send(message)
+                    # TODO Can we ack that the cmd was applied?
+
+            else:
+                pass 
+                # TODO Maybe we can set some status to indicate we cannot arm?
+
+
+           # TODO We need to drop out of AP mode, alert pilot if system is in a bad state
+           # unhealthy GPS signal is one such state
+           # Not sure what all we need to check for
+
+
+    def init(self):
+        self.parent.db_write("ROLL", 0)
+        self.parent.db_write("PITCH", 0)
+        self.parent.db_write("HEAD", 0)
+        self.parent.db_write("AGL", 0)
+        self.parent.db_write("ALT", 0)
+        self.parent.db_write("VS", 0)
+
+    def checkInit(self,mode):
+        if self._apmode == 'INIT':
+            self._apmode = mode
+            self._apreq = mode
+            self.parent.db_write("APMODE", mode) 
+
+    def sendMode(self,mode,msg):
+        self.parent.db_write("APMODE", mode)
+        self.parent.db_write("APMSG", msg)
+
+
+    def setStat(self,stat,msg=None):
+        self.parent.db_write("APSTAT", stat)
+        self._apstat = stat
+        if msg:
+            self.parent.db_write("APMSG", msg)
+
+
+    def sendTrims(self):
+        # TODO I suspect we do not want to send trims sometimes.
+        # Also, we need to send only zero when in modes other than TRIM
+        # Unless the pilot is wanting to change course/altitude.
+        # Seems like some non-latching three position toggle switches
+        # might work well
+        # Pilot could hold up/down to change altitude or 
+        # hold right/left to change heading
+        # Once on heading let go of switch and AP will maintain
+        self.conn.mav.manual_control_send(
+            self.conn.target_system,
+            self.parent.db_read("TRIMP")[0], #pitch
+            self.parent.db_read("TRIMR")[0], #roll
+            0, #Throttle
+            self.parent.db_read("TRIMY")[0], #Yaw
+            0
+        )
+
+    def checkMode(self):
+        self.checkWaypoint()
+        # Check if a mode change has been requested
+        if self._apreq != self.parent.db_read("APREQ")[0]\
+           and self.parent.db_read("APREQ")[0] != 'INIT':
+            # Set the mode
+            self.setMode(self.parent.db_read("APREQ")[0])
+
+    def checkWaypoint(self):
+        # We need to take actions when the waypoint changes or is deleted
+        # For example, if the pilot deletes the flight plan or communication is lost
+        # with whatever is providing the waypoints.
+        if self.parent.db_read('WPLAT')[2] or self.parent.db_read('WPLON')[2] or (self.parent.db_read('WPLAT')[0] == 0.0 or self.parent.db_read('WPLON')[0] == 0.0):
+            # The WPLAT/LON are old or not set
+            # IF we are in GUIDED mode we want to drop to CRUISE mode
+            if self._apreq == 'GUIDED':
+                # drop to CRUISE mode ( Heading Hold )
+                self.setMode('CRUISE')
+                self.parent.db_write('APMSG', "Drop to Heading Hold")
+                # Invalidate the waypoint
+            self._apwpv = False
+            return
+        else:
+            # We do have a valid waypoint
+            self._apwpv = True
+            # Did the waypoint change?
+            if self._waypoint != f"{self.parent.db_read('WPLON')[0]}{self.parent.db_read('WPLAT')[0]}{self.parent.db_read('WPNAME')[0]}" and self._apmode == 'GUIDED':
+                self.setMode('GUIDED')
+ 
+    def setMode(self, mode):
+        # Can we set that mode?
+        if self._apstat in ['TRIM','ARMED'] and mode in self._apmodes:
+            if mode not in ['TRIM'] and (( mode == 'GUIDED' and not self._apwpv) or (self._apstat != 'ARMED')):
+                # Cruise mode requested but we are not armed
+                # or do not have a valid waypoint
+                
+                self.parent.db_write("APMSG", "Invalid Request")
+                # This will disrupt AHRS
+                # TODO Maybe we need a better way to inform the pilot to the change?
+                time.sleep(3)
+                self.parent.db_write("APREQ", self._apmode)
+                return
+
+            if mode == 'GUIDED':
+                # Request is for guided mode so we need to set the mode differently
+                self._waypoint = f"{self.parent.db_read('WPLON')[0]}{self.parent.db_read('WPLAT')[0]}{self.parent.db_read('WPNAME')[0]}"
+                message = self.conn.mav.command_int_encode(
+                    self.conn.target_system,
+                    self.conn.target_component,
+                    mavutil.mavlink.MAV_FRAME_GLOBAL,
+                    mavutil.mavlink.MAV_CMD_DO_REPOSITION, # Command
+                    0, # not used
+                    0, # not used
+                    0, # default speed
+                    1, # goto location now
+                    0, # radius
+                    0, # loiter direction
+                    int(self.parent.db_read('WPLAT')[0] * 10**7), # int32_t degE7
+                    int(self.parent.db_read('WPLON')[0] * 10**7),
+                    self.parent.db_read('ALT')[0] * .3048 # altitude ALT is in ft, mavlink uses meters
+                )
+            else:
+                message = self.conn.mav.command_long_encode(
+                    self.conn.target_system,
+                    self.conn.target_component,
+                    mavutil.mavlink.MAV_CMD_DO_SET_MODE,  # command to send
+                    0,  
+                    mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,  # custom mode
+                    self._apmodes[mode],     # param2: custom mode to set
+                    0,       # param3 not used
+                    0,       # param4 not used
+                    0,       # param5 not used
+                    0,       # param5 not used
+                    0        # param6 not used
+                )
+            # Send the command
+            self.conn.mav.send(message)
+            self._apreq = mode
+
+            # Set APREQ to in case the mode change was made internally
+            self.parent.db_write("APREQ", mode)
+            self.parent.db_write("APMODE", mode)
+            self._apmode = mode
+        else:
+            # TODO Likely need more logic here
+            pass 
+
+

--- a/fixgw/plugins/mavlink/Mav.py
+++ b/fixgw/plugins/mavlink/Mav.py
@@ -142,8 +142,9 @@ class Mav:
             if self._ahrs:
                 self.parent.db_write("HEAD", round(msg.hdg/100,2))             # uint16_t cdeg 
                 self.parent.db_write("AGL", round(msg.relative_alt / 304.8,2)) # int32_t mm to ft
-                # Should this be TALT?:
+                # Seems like MSD is TALT and ALT should be indicated, not sure hoe to get both:
                 self.parent.db_write("ALT", round(msg.alt / 304.8, 2))          # int32_t mm to ft
+                self.parent.db_write("TALT", round(msg.alt / 304.8, 2))          # int32_t mm to ft
             if self._gps:
                 self.parent.db_write("LAT",msg.lat/10000000.0)        # int32_t degE7 10**7
                 self.parent.db_write("LONG",msg.lon/10000000.0)       # int32_t degE7 10**7

--- a/fixgw/plugins/mavlink/__init__.py
+++ b/fixgw/plugins/mavlink/__init__.py
@@ -1,0 +1,129 @@
+#  Copyright (c) 2023 Eric Blevins
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+#  USA.import plugin
+
+# This plugin will connect to a hobby flight controler such as Ardupilot/pixhawk.
+# It uses the mavlink protocol to communicate
+# The primary use for this is a source of accurate GPS, AHRS and airspeed data
+# Connected to servo controlled trim tabs some of the auto pilot features
+# might be usable.
+#
+# This code has not seen any real-world testing
+# Use at your own risk!!!
+# If you do not understand what the code does and trust it then you should not use it!
+
+import threading
+import time
+import logging
+from collections import OrderedDict
+import fixgw.plugin as plugin
+from fixgw.plugins.mavlink.Mav import Mav
+
+import math
+
+class MainThread(threading.Thread):
+    def __init__(self, parent):
+        super(MainThread, self).__init__()
+        #print("running mavlink plugin")
+        self.getout = False   # indicator for when to stop
+        self.parent = parent  # parent plugin object
+        self.log = parent.log  # simplifies logging
+        self.config = parent.config
+
+        # Trims -1000 to 1000
+        self.pitch = 0
+        self.yaw = 0
+        self.roll = 0
+
+    def run(self):
+        self._type = self.config['type']
+        self.baud = int(self.config['baud']) if ( 'baud' in self.config) else 57600
+        self.port = self.config['port'] if ( 'port' in self.config) else '/dev/ttyACM0'
+
+        while not self.getout:
+            time.sleep(0.00001)
+            try:
+                print("Mav init")
+                self.conn = Mav(self.parent, port=self.port, baud=self.baud)
+            except Exception as e:
+                try:
+                    print(e) 
+                    self.conn.close()
+                except Exception:
+                    self.log.debug(f"Mavlink failed to connect")
+ 
+                self.log.debug(f"Mavlink failed to connect, trying again in 1 second type: {self._type} port: {self.port} baud: {self.baud}")
+                self.log.debug(e)
+                time.sleep(1)      
+                continue
+            self.log.debug("Wait for heartbeat")
+            try: self.conn.wait_heartbeat()
+            except Exception as e:
+                self.conn.close()
+                self.log.debug(f"Mavlink failed wait_heartbeat")
+                self.log.debug(e)
+                time.sleep(1)
+                continue
+
+            self.log.debug("processing messages")
+            loopc = 1
+            while not self.getout:
+                time.sleep(0.001)
+                try:
+                    self.conn.process()
+                    self.conn.sendTrims()
+                    # Processing AHRS and Trim is more important than
+                    # changing auto pilot modes
+                    # So we only deal with the AP once every 10 cycles
+                    if loopc > 10:
+                        self.conn.checkMode()
+                        loopc = 0
+                    loopc += 1
+                except Exception as e:
+                    self.conn.close()
+                    self.log.debug(f"Mavlink failed while processing messages")
+                    self.log.debug(e)
+                    time.sleep(1)
+                    break
+            self.running = False
+
+    def stop(self):
+        self.getout = True
+
+
+class Plugin(plugin.PluginBase):
+    def __init__(self, name, config):
+        super(Plugin, self).__init__(name, config)
+        if config['type'] == 'serial':
+          self.thread = MainThread(self)
+          self.status = OrderedDict()   
+        else:
+            raise ValueError("Only serial type is implemented")
+
+    def run(self):
+
+        self.thread.start()
+
+    def stop(self):
+        self.thread.stop()
+        if self.thread.is_alive():
+            self.thread.join(1.0)
+        if self.thread.is_alive():
+            raise plugin.PluginFail
+
+    def get_status(self):
+        return self.status
+

--- a/fixgw/plugins/mavlink/__init__.py
+++ b/fixgw/plugins/mavlink/__init__.py
@@ -52,12 +52,13 @@ class MainThread(threading.Thread):
         self._type = self.config['type']
         self.baud = int(self.config['baud']) if ( 'baud' in self.config) else 57600
         self.port = self.config['port'] if ( 'port' in self.config) else '/dev/ttyACM0'
+        self.options = self.config['options'] if ( "options" in self.config) else {}
 
         while not self.getout:
             time.sleep(0.00001)
             try:
                 print("Mav init")
-                self.conn = Mav(self.parent, port=self.port, baud=self.baud)
+                self.conn = Mav(self.parent, port=self.port, baud=self.baud, options=self.options)
             except Exception as e:
                 try:
                     print(e) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lockfile
 daemon
 pyyaml
 pymavlink
+pynmea2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-canfix
 lockfile
 daemon
 pyyaml
+pymavlink


### PR DESCRIPTION
The iFly plugin will capture NMEA data sent by iFly EFB app and populate WPNAME, WPLON and WPLAT with the next destination of your flight plan in iFly.

The mavlink plugin connects to a hobby flight controller to get GPS/AHRS data, it could possibly also be used as an auto pilot.
I plan to also add support for getting airspeed data once I get a compatible airspeed sensor for my controller.