### PR TITLE
Updated canfix and mavlink

### DIFF
--- a/fixgw/config/database/mavlink.yaml
+++ b/fixgw/config/database/mavlink.yaml
@@ -17,6 +17,10 @@ items:
   type: bool
   initial: False
 
+- key: MAVREQAUTO
+  type: bool
+  initial: False
+
 - key: MAVREQCRUISE
   type: bool
   initial: False
@@ -42,13 +46,13 @@ items:
   type: str
   initial: ""
 
-- key: MAVREQ
-  description: Mode of auto pilot that is requested
-  type: str
-  initial: "INIT"
+- key: MAVREQADJ
+  description: Request heading or altitude adjustment mode
+  type: bool
+  initial: False
 
 - key: MAVADJ
-  description: Adjust heading/altitude of auto pilot using trim controls
+  description: Identifies if adjustment mode is enabled
   type: bool
   initial: False
 

--- a/fixgw/plugins/canfix/mapping.py
+++ b/fixgw/plugins/canfix/mapping.py
@@ -333,11 +333,22 @@ class Mapping(object):
             bit = 0
             byte = 0
             for each in switches:
+                if each.key in self.output_mapping:
+                    output_exclude = True
+                    self.output_mapping[each.key]['exclude'] = True
+                else:
+                    output_exclude = False
+
                 if toggles.get(each.key,False):
                     if x[byte][bit]:
+                        if output_exclude:
+                            self.output_mapping[each.key]['lastValue'] = not each.value[0]
                         # toggle only when we receive True
                         each.value = not each.value[0]
                 else:
+                    if output_exclude:
+                        self.output_mapping[each.key]['lastValue'] = x[byte][bit]
+
                     each.value = x[byte][bit]
                 bit += 1
                 if bit >=8:

--- a/fixgw/plugins/canfix/mapping.py
+++ b/fixgw/plugins/canfix/mapping.py
@@ -149,10 +149,13 @@ class Mapping(object):
             m = self.output_mapping[dbKey]
             self.log.debug(f"Output {dbKey}: {value[0]}")
             if m["require_leader"] and not quorum.leader:
+            self.log.debug(f"LEADER blocked Output {dbKey}: {value[0]}")
                 return
+
             # If the exclude flag is set we just recieved the value
             # from the bus so we don't turn around and write it back out
             if m['exclude']:
+            self.log.debug(f"Resend protection blocked Output {dbKey}: {value[0]}")
                 m['exclude'] = False
                 return
             if m['switch']:

--- a/fixgw/plugins/canfix/mapping.py
+++ b/fixgw/plugins/canfix/mapping.py
@@ -149,13 +149,13 @@ class Mapping(object):
             m = self.output_mapping[dbKey]
             self.log.debug(f"Output {dbKey}: {value[0]}")
             if m["require_leader"] and not quorum.leader:
-            self.log.debug(f"LEADER blocked Output {dbKey}: {value[0]}")
+                self.log.debug(f"LEADER blocked Output {dbKey}: {value[0]}")
                 return
 
             # If the exclude flag is set we just recieved the value
             # from the bus so we don't turn around and write it back out
             if m['exclude']:
-            self.log.debug(f"Resend protection blocked Output {dbKey}: {value[0]}")
+                self.log.debug(f"Resend protection blocked Output {dbKey}: {value[0]}")
                 m['exclude'] = False
                 return
             if m['switch']:

--- a/fixgw/plugins/mavlink/__init__.py
+++ b/fixgw/plugins/mavlink/__init__.py
@@ -62,11 +62,12 @@ class MainThread(threading.Thread):
         def requestCallback(fixkey, value, udata):
             for f in self.req:
                 if f"MAVREQ{f}" == fixkey:
-                    self.req[f] = value[0]
+                    if self.req[f] != value[0]:
+                        self.req[f] = value[0]
                 else:
                     # Only change others to false if
                     # key is getting set to True
-                    if value[0]:
+                    if value[0] and self.req[f]:
                         self.req[f] = False
                         self.parent.db_write(f"MAVREQ{f}", False)
         return requestCallback

--- a/fixgw/plugins/mavlink/__init__.py
+++ b/fixgw/plugins/mavlink/__init__.py
@@ -48,39 +48,12 @@ class MainThread(threading.Thread):
         self.yaw = 0
         self.roll = 0
 
-        # The modes we can request:
-        self.req = {
-          'TRIM': False,
-          'CRUISE': False,
-          'AUTOTUNE': False,
-          'GUIDED': False,
-        }
-
-    # Callback to set the requested mode
-    # Only once mode can be set at a time.
-    def getRequestFunction(self,mode):
-        def requestCallback(fixkey, value, udata):
-            for f in self.req:
-                if f"MAVREQ{f}" == fixkey:
-                    if self.req[f] != value[0]:
-                        self.req[f] = value[0]
-                else:
-                    # Only change others to false if
-                    # key is getting set to True
-                    if value[0] and self.req[f]:
-                        self.req[f] = False
-                        self.parent.db_write(f"MAVREQ{f}", False)
-        return requestCallback
-
     def run(self):
         self._type = self.config['type']
         self.baud = int(self.config['baud']) if ( 'baud' in self.config) else 57600
         self.port = self.config['port'] if ( 'port' in self.config) else '/dev/ttyACM0'
         self.options = self.config['options'] if ( "options" in self.config) else {}
         
-        for f in self.req:
-            self.parent.db_callback_add(f"MAVREQ{f}",self.getRequestFunction(f))
-
         while not self.getout:
             time.sleep(0.00001)
             try:
@@ -117,7 +90,7 @@ class MainThread(threading.Thread):
                     # changing auto pilot modes
                     # So we only deal with the AP once every 10 cycles
                     if loopc > 10:
-                        self.conn.checkMode(self.req)
+                        self.conn.checkMode()
                         loopc = 0
                     loopc += 1
                 except Exception as e:


### PR DESCRIPTION
canfix was not blocking re-sending switch inputs like normal inputs do, this has been addressed.
Likely need to look into the encoders for this problem too

Mavlink was modified to change how it changes modes to make it easier and more reliable when accessing the flight controller from multiple fix gateways/pyefis at the same time. I am using a switch canfix id to sync the mode switches across systems and is how I found the issue above.