### PR TITLE
Automating version info

### DIFF
--- a/fixgw/config/database/system.yaml
+++ b/fixgw/config/database/system.yaml
@@ -67,10 +67,19 @@ items:
   max: 12.0
   initial: 0.0
 
+- key: GATEWAY_VERSION
+  description: Version of the gateway
+  type: str
+  tol: 0
 
+- key: PYEFIS_VERSION
+  description: Version of pyefis
+  type: str
+  tol: 0
 
 - key: ZZLOADER
   description: MUST always be the last key listed here. It is read by client applications to ensure all db items have been init before proceeding to prevent race conditions.
   type: str
   initial: "Loaded"
+
 

--- a/fixgw/server.py
+++ b/fixgw/server.py
@@ -15,7 +15,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
+from fixgw import version
 import yaml
 try:
     import queue
@@ -198,6 +198,7 @@ def main_setup():
         log.error("Database failure, Exiting:" + str(e))
         raise
 
+    database.write('GATEWAY_VERSION', version.VERSION)
     if "initialization files" in config and config["initialization files"]:
         ifiles = config["initialization files"]
         for fn in ifiles:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: fixgateway
-version: "2.0.10"
+adopt-info: fixgateway
 grade: stable
 license: GPL-2.0+
 summary: makerplane FIX gateway server
@@ -48,6 +48,9 @@ parts:
   fixgateway:
     plugin: python
     source: .
+    override-build: |
+      craftctl default
+      craftctl set version=$(python3 fixgw/version.py)
     stage-packages:
       - libarchive13t64
       - cmake


### PR DESCRIPTION
Added version.py that is used to populate the FIX DB key GATEWAY_VERSION and used within the snapcraft.yaml to automatically set the snap version.