### PR TITLE
Add moving-map control-binding keys (MAPRANGE/MAPORIENT/MAPTERRAIN)

### DIFF
--- a/src/fixgw/config/database.yaml
+++ b/src/fixgw/config/database.yaml
@@ -16,6 +16,7 @@ entries:
 - include: database/mavlink.yaml
 - include: database/system.yaml
 - include: database/control.yaml
+- include: database/map.yaml
 - include: database/misc.yaml
 - include: database/tires.yaml
 #################################################

--- a/src/fixgw/config/database/map.yaml
+++ b/src/fixgw/config/database/map.yaml
@@ -1,0 +1,31 @@
+# Moving-map control/setting keys.
+#
+# Avoid editing this file -- future updates may change it, and once edited it
+# will no longer be auto-updated. To change min/max/initial/tol, use custom.ini.
+#
+# These keys let a button or knob drive the pyEFIS moving map at runtime: a
+# control writes the key and the map derives the setting.
+items:
+- key: MAPRANGE
+  description: "Moving map range (ladder index)"
+  type: int
+  min: 0
+  max: 7                 # steps in the default ladder 2,5,10,20,40,80,160
+  units: index
+  initial: 2             # index of 10 NM = the map's default range
+  tol: 0
+
+- key: MAPORIENT
+  description: "Moving map orientation (0=track up, 1=north up)"
+  type: int
+  min: 0
+  max: 2
+  units: index
+  initial: 0
+  tol: 0
+
+- key: MAPTERRAIN
+  description: "Moving map terrain layer on/off"
+  type: bool
+  initial: true
+  tol: 0


### PR DESCRIPTION
Adds three FIX database keys so a UI control (button or knob) can drive the pyEFIS moving map at runtime: the display writes the key and the map derives the setting.

- `MAPRANGE` — range as an index into the range ladder (max = ladder step count, so a wrap-on-change control cycles every step and rolls over)
- `MAPORIENT` — orientation (0 = track up, 1 = north up)
- `MAPTERRAIN` — terrain layer on/off

The keys live in a new versioned `config/database/map.yaml`, wired into `database.yaml` alongside the other domain files, so they load out of the box and are picked up on update (rather than sitting in the user-owned `custom.yaml`). Purely additive — no behavior change for existing setups; unused if no map screen is configured.

These pair with the moving-map controls in the corresponding pyEFIS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)